### PR TITLE
[#20] Fix for clipboard=unnamedplus

### DIFF
--- a/autoload/yankstack.vim
+++ b/autoload/yankstack.vim
@@ -106,7 +106,9 @@ endfunction
 
 function! s:default_register()
   let clipboard_flags = split(&clipboard, ',')
-  if index(clipboard_flags, 'unnamed') >= 0
+  if index(clipboard_flags, 'unnamedplus') >= 0
+    return "+"
+  elseif index(clipboard_flags, 'unnamed') >= 0
     return "*"
   else
     return "\""

--- a/spec/yankstack/yankstack_spec.rb
+++ b/spec/yankstack/yankstack_spec.rb
@@ -326,6 +326,12 @@ describe "Yankstack" do
   end
 
   describe "when the `unnamedplus` clipboard option is enabled" do
+    before { vim.set "clipboard", "unnamedplus" }
+
+    it_has_behavior "yanking and pasting"
+  end
+
+  describe "when the `unnamed,unnamedplus` clipboard option is enabled" do
     before { vim.set "clipboard", "unnamed,unnamedplus" }
 
     it_has_behavior "yanking and pasting"


### PR DESCRIPTION
Fix for `clipboard=unnamedplus`, which allows vim to connect with the X11 clipboard.
