### PR TITLE
let yankstack keys be customized

### DIFF
--- a/autoload/yankstack.vim
+++ b/autoload/yankstack.vim
@@ -153,7 +153,10 @@ function! yankstack#setup()
   if exists('g:yankstack_did_setup') | return | endif
   let g:yankstack_did_setup = 1
 
-  let yank_keys  = ['c', 'C', 'd', 'D', 's', 'S', 'x', 'X', 'y', 'Y']
+  if !exists('g:yankstack#yank_keys')
+      let g:yankstack#yank_keys  = ['c', 'C', 'd', 'D', 's', 'S', 'x', 'X', 'y', 'Y']
+  endif
+  let yank_keys  = g:yankstack#yank_keys
   let paste_keys = ['p', 'P', 'gp', 'gP']
   let word_characters = split("qwertyuiopasdfghjklzxcvbnm1234567890_", '\zs')
 


### PR DESCRIPTION
Hi - minor change to allow yank keys to be customized. Much easier if you don't want s & S to be intercepted by yankstack.
