### PR TITLE
Avoid pasting from the blackhole register

### DIFF
--- a/autoload/yankstack.vim
+++ b/autoload/yankstack.vim
@@ -19,7 +19,8 @@ function! s:yank_with_key(key)
 endfunction
 
 function! s:paste_with_key(key, mode, register, count)
-  return s:paste_from_yankstack(a:key, a:mode, a:register, a:count, 1)
+  let final_reg = a:register ==# '_' ? s:default_register() : a:register
+  return s:paste_from_yankstack(a:key, a:mode, final_reg, a:count, 1)
 endfunction
 
 function! s:paste_from_yankstack(key, mode, register, count, is_new)


### PR DESCRIPTION
Yankstack's mappings (line 170) rely on Vim's `v:register` variable to define the currently active register. However, there's one oddity about the `v:register`: after yanking/deleting something its value doesn't update until the cursor is moved or some other action is performed (try doing `"_x:echo v:register`, apparently it's intended). That means that if you delete something into the blackhole register for instance, and then immediately use Yankstack to paste without specifying a register, the `paste_with_key` function receives the previously used `_` in the parameter `a:register` instead of `"` which is what the user would expect. In other words, Yankstack will try to paste from the blackhole register instead of the default register with `p` if the previous command used the blackhole reg.

The commit simply transforms the blackhole register into default register when pasting. This fixes pasting with plain `p` so you can do `"_xP` for instance. Pastes using an explicit register are unaffected, apart from the blackhole register which I don't think anybody has any reason to paste from.

I _haven't_ tested the commit with the suite since I'm unfamiliar with Ruby and kind of preoccupied. It's been working for me for a while though and it seems like a harmless change.
