### PR TITLE
After setup callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ nmap Y y$
 " other mappings involving y, d, c, etc
 ```
 
+Alternatively, if you can't afford to call 'yankstack#setup()' too early in
+your |vimrc| you can still tell yankstack to call a user defined function when
+the initial setup has run:
+
+```
+function! YankStackAfterSetup()
+    nmap Y y$
+endfunction
+let g:yankstack_after_setup = 'YankStackAfterSetup'
+```
+
 You can also prevent certain keys from being remapped by setting the `g:yankstack_yank_keys`
 to the keys of your choosing. For example, if you only want Yankstack to remap `y` and `d`:
 
@@ -94,6 +105,8 @@ Check it out on [github](https://github.com/maxbrunsfeld/vim-yankstack)!
 
 ## Changelog ##
 
+### 1.0.7 (2017-10-07)
+  - Allow function to be executed after initial setup has run.
 
 ### 1.0.6 (2014-08-04)
   - Allow customization of the list of keys to be remapped.

--- a/autoload/yankstack.vim
+++ b/autoload/yankstack.vim
@@ -173,6 +173,10 @@ function! yankstack#setup()
   for key in word_characters
     exec 'smap <expr>' key '<SID>yank_with_key("' . key . '")'
   endfor
+
+  if exists('g:yankstack_after_setup')
+      exec 'call '.g:yankstack_after_setup.'()'
+  endif
 endfunction
 
 nnoremap <silent> <Plug>yankstack_substitute_older_paste :<C-u>call <SID>substitute_paste(v:count1, 'n')<CR>

--- a/doc/yankstack.txt
+++ b/doc/yankstack.txt
@@ -86,7 +86,19 @@ mappings of your own. To achieve this, just call 'yankstack#setup()'in your
   call yankstack#setup()
   nmap Y y$
 
+Alternatively, if you can't afford to call 'yankstack#setup()' too early in
+your |vimrc| you can still tell yankstack to call a user defined function when
+the initial setup has run:
+
+  function! YankStackAfterSetup()
+      nmap Y y$
+  endfunction
+  let g:yankstack_after_setup = 'YankStackAfterSetup'
+
 CHANGELOG                                       *yankstack-changelog*
+
+1.0.7 (2017-10-07)
+  - Allow function to be executed after initial setup has run.
 
 1.0.5 (2012-07-19)
   - Fix bug where on certain versions of vim, the first time you tried

--- a/doc/yankstack.txt
+++ b/doc/yankstack.txt
@@ -100,6 +100,9 @@ CHANGELOG                                       *yankstack-changelog*
 1.0.7 (2017-10-07)
   - Allow function to be executed after initial setup has run.
 
+1.0.6 (2014-08-04)
+  - Allow customization of the list of keys to be remapped.
+
 1.0.5 (2012-07-19)
   - Fix bug where on certain versions of vim, the first time you tried
     to cycle through your yanks after doing a normal paste, an extra


### PR DESCRIPTION
This PR adds support for a user defined function that yankstack will run after the initial setup.

I recently switched from pathogen to Vim's built-in support for plugins, and noticed that calling `yankstack#setup()` to get custom mappings set up did not work anymore; it turns out I have to throw a `packloadall` somewhere in my vimrc, but that breaks other things.

So I thought: why not let the user know when the initial setup is complete?  I could then add the following to my vimrc, and call it a day:

```
function! YankStackAfterSetup()
    nmap Y y$
    nmap D d$
    nmap gp <Plug>yankstack_substitute_older_paste
    nmap gP <Plug>yankstack_substitute_newer_paste
endfunction

let g:yankstack_after_setup = 'YankStackAfterSetup'
```

What do you think about that?  Can you think of a better way to solve this?

Ciao,
Matteo